### PR TITLE
Pack bits tighter for bigger numbers in smaller sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ However *"must"* means that it is not considered spec compliant without said beh
 
 ## Integer Pair Encoding
 
-There are 5 possible encoding patterns depending on the size of the second number:
+There are 5 possible encoding patterns depending on the prefix of the second number:
 
 ```js
-xxxx yyyy
-xxxx 1100 yyyyyyyy
-xxxx 1101 yyyyyyyy yyyyyyyy
-xxxx 1110 yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy
-xxxx 1111 yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy
+xxxx 0yyy (u3 0x8 values)
+xxxx 10yy yyyyyyyy (u10 0x400 values)
+xxxx 110y yyyyyyyy yyyyyyyy yyyyyyyy (u25 0x2000000 values)
+xxxx 1110 yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy (u56 0x1000000 values)
+xxxx 1111 yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy (u64 0x100000000 values)
 ```
 
 Here the `x`s are a `u4` and the `y`s are semantically a `u64` using zero extension on the smaller numbers.


### PR DESCRIPTION
The original design has less masking when reading values, but requires more bytes to encode many common numbers.

This proposal is to pack the numbers a little tighter and allow more bits for middle sizes.  Also with most encoding being powers of 2 in the new design, there should be more aligned reads in memory.

```
xxxx 0yyy (u3 0x8 values)
xxxx 10yy yyyyyyyy (u10 0x400 values)
xxxx 110y yyyyyyyy yyyyyyyy yyyyyyyy (u25 0x2000000 values)
xxxx 1110 yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy (u56 0x1000000 values)
xxxx 1111 yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy yyyyyyyy (u64 0x100000000 values)
```

| Old Bytes | Old Range | New Bytes | New Range |
| ---|---|---|---|
| 1 byte | 12 values | 1 byte | 8 values
| 2 bytes | 256 values | 2 bytes | 1,024 values (1Ki)
| 3 bytes | 65,536 values (65Ki) | 4 bytes | 33,554,432 values (32Mi)
| 5 bytes |  4,294,967,296 values (4Gi) | 8 bytes | 72,057,594,037,927,936 values (64Pi)
| 9 bytes | 18,446,744,073,709,551,616 values (16Zi) | 9 bytes | 18,446,744,073,709,551,616 values (16Zi)

The 1 byte encoding gets a little worse as its range drops from `12` to `8`, but the 2 byte encoding gets 4x bigger from `256` to `1024`.  More values in practice will fall in this range so it's good to optimize for it.  For example it gives us 4x the number of refs that fit in two bytes.

The 3 byte encoding gets upgraded to a 4 byte encoding with a massive jump in range that should be plenty for most binary file offsets up to 32MiB.

The 5 byte encoding gets a likewise upgrade to 8 bytes with enough range to encode *all* integers in the 64bit double precision floats.

The 9 byte encoding it left alone for cases where the full 64 bits of precision is required.